### PR TITLE
Reduce width of table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,6 @@ go 1.19
 
 require github.com/mattn/go-sqlite3 v1.14.15
 
-require (
-	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/urfave/cli/v2 v2.14.0 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-)
+require github.com/urfave/cli/v2 v2.14.0
 
-require (
-	github.com/jedib0t/go-pretty/v6 v6.3.7
-	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
-)
+require github.com/jedib0t/go-pretty/v6 v6.3.7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -27,6 +28,8 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRT
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

When titles and/or authors are long, the resulting book list table wraps in a way that this difficult to read. This modification addresses that tendency.

The table width is reduced in several ways:

1. “NUMBER OF NOTES” is now “# NOTES”
2. The title is truncated after 30 characters
3. The author’s name is reduced, for example “Doe Ph.D., John” is just “(Doe)”. Several other cases are handled correctly.

So the table column for title and author will read like: "My Great Book (Doe)"

## Author name reduction tests:

```
fmt.Println(GetLastNames("Dr. Nate Zinsser")) // (Zinsser)
fmt.Println(GetLastNames("Chamorro-Premuzic Ph.D., Tomas")) // (Chamorro-Premuzic)
fmt.Println(GetLastNames("Bertrand Russell")) // (Russell)
fmt.Println(GetLastNames("John Doe, M.D.")) // (Doe)
fmt.Println(GetLastNames("John Doe, MD, PhD, FACP")) // (Doe)
fmt.Println(GetLastNames("Anders Ericsson & Robert Pool")) // (Anders & Pool)
```

It is possible that there are author name formats that fall outside of this scope and will need to be accommodated.